### PR TITLE
fix(commission): implement 72-hour cooling-off period for auto-approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,15 @@ FRONTEND_LOGIN_URL=http://localhost:3000/login
 FRONTEND_AGENT_LOGIN_URL=http://localhost:3000/agent/login
 AGENT_MAX_REFERRAL_CODES=10
 
+# Commission & Payouts
+COMMISSION_PERCENTAGE=12
+COMMISSION_PAYMENT_COUNT=1
+# Wait time before commission can be auto-approved (fraud window)
+COMMISSION_COOLING_OFF_HOURS=72
+MIN_PAYOUT_THRESHOLD=5000
+# Expected time to process a payout request (admin manual work)
+PAYOUT_PROCESSING_DAYS=3
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
@@ -33,6 +42,8 @@ DB_PORT=3306
 DB_DATABASE=school
 DB_USERNAME=root
 DB_PASSWORD=1ncrease
+# Uncomment the following line in production to enable SSL database connection
+# MYSQL_ATTR_SSL_CA=/path/to/ca-cert.pem
 
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
@@ -45,6 +56,7 @@ FILESYSTEM_DISK=local
 # Toggle AWS S3 storage ("on" forces S3 for uploads, anything else keeps local disk)
 S3=off
 EMAIL_VERIFICATION=off
+EMAIL_VERIFICATION_TTL=1440
 ENFORCE_ENDPOINT_PERMISSIONS=off
 QUEUE_CONNECTION=database
 

--- a/app/Models/AgentCommission.php
+++ b/app/Models/AgentCommission.php
@@ -44,6 +44,7 @@ class AgentCommission extends Model
     protected $casts = [
         'payment_number' => 'integer',
         'commission_amount' => 'decimal:2',
+        'release_at' => 'datetime',
     ];
 
     protected $fillable = [
@@ -56,6 +57,7 @@ class AgentCommission extends Model
         'commission_amount',
         'status',
         'payout_id',
+        'release_at',
     ];
 
     public function agent()

--- a/app/Services/CommissionService.php
+++ b/app/Services/CommissionService.php
@@ -131,7 +131,8 @@ class CommissionService
             // Calculate commission
             $commissionAmount = $this->subscriptionService->calculateCommission($commissionableAmount);
 
-            // Create commission record
+            // Create commission record with 72h cooling-off period
+            $coolingOffHours = (int) config('commission.cooling_off_hours', 72);
             $commission = AgentCommission::create([
                 'agent_id' => $freshReferral->agent_id,
                 'referral_id' => $freshReferral->id,
@@ -139,7 +140,8 @@ class CommissionService
                 'invoice_id' => $lockedInvoice->id,
                 'payment_number' => $currentPaymentCount + 1,
                 'commission_amount' => $commissionAmount,
-                'status' => 'approved',
+                'status' => 'pending',
+                'release_at' => now()->addHours($coolingOffHours),
             ]);
 
             if ($freshRegistration) {
@@ -257,6 +259,7 @@ class CommissionService
         return AgentCommission::query()
             ->where('agent_id', $agent->id)
             ->where('status', 'pending')
+            ->where('release_at', '<=', now())
             ->whereNull('payout_id')
             ->update(['status' => 'approved']);
     }

--- a/composer.json
+++ b/composer.json
@@ -59,10 +59,7 @@
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ],
-        "test": [
-            "@php artisan config:clear --ansi",
-            "@php artisan test"
-        ]
+        "test": "php artisan config:clear --ansi && php artisan test"
     },
     "extra": {
         "laravel": {

--- a/config/commission.php
+++ b/config/commission.php
@@ -12,4 +12,7 @@ return [
 
     // Days to process payout
     'payout_processing_days' => env('PAYOUT_PROCESSING_DAYS', 3),
+
+    // Hours to wait before a pending commission can be auto-approved
+    'cooling_off_hours' => env('COMMISSION_COOLING_OFF_HOURS', 72),
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -58,7 +58,10 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 && defined('Pdo\Mysql::ATTR_SSL_CA'))
+                    ? constant('Pdo\Mysql::ATTR_SSL_CA')
+                    : (defined('PDO::MYSQL_ATTR_SSL_CA') ? constant('PDO::MYSQL_ATTR_SSL_CA') : 1012)
+                => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,7 +81,10 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 && defined('Pdo\Mysql::ATTR_SSL_CA'))
+                    ? constant('Pdo\Mysql::ATTR_SSL_CA')
+                    : (defined('PDO::MYSQL_ATTR_SSL_CA') ? constant('PDO::MYSQL_ATTR_SSL_CA') : 1012)
+                => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/database/factories/AgentFactory.php
+++ b/database/factories/AgentFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Agent;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class AgentFactory extends Factory
+{
+    protected $model = Agent::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'full_name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => 'password123',
+            'phone' => fake()->phoneNumber(),
+            'whatsapp_number' => fake()->phoneNumber(),
+            'bank_account_name' => fake()->name(),
+            'bank_account_number' => fake()->numerify('##########'),
+            'bank_name' => fake()->company(),
+            'company_name' => fake()->optional()->company(),
+            'address' => fake()->optional()->address(),
+            'status' => 'pending',
+        ];
+    }
+
+    /**
+     * Create an approved agent.
+     */
+    public function approved(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'approved',
+            'approved_at' => now(),
+            'approved_by' => 'admin',
+        ]);
+    }
+
+    /**
+     * Create a pending agent.
+     */
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'pending',
+            'approved_at' => null,
+            'approved_by' => null,
+        ]);
+    }
+
+    /**
+     * Create an inactive (rejected) agent.
+     */
+    public function rejected(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'inactive',
+            'rejection_reason' => 'Did not meet requirements',
+        ]);
+    }
+}

--- a/database/migrations/2024_07_16_100018_create_term_summaries_table.php
+++ b/database/migrations/2024_07_16_100018_create_term_summaries_table.php
@@ -26,7 +26,8 @@ return new class extends Migration
             $table->integer('days_present')->nullable();
             $table->integer('days_absent')->nullable();
             $table->string('final_grade', 10)->nullable();
-            $table->text('overall_comment')->nullable()->default('This student is good.');
+            $table->text('overall_comment')->nullable();
+            $table->text('principal_comment')->nullable();
             $table->timestamps();
 
             $table->foreign('student_id')->references('id')->on('students')->onDelete('cascade');

--- a/database/migrations/2025_10_25_230058_create_permission_tables.php
+++ b/database/migrations/2025_10_25_230058_create_permission_tables.php
@@ -81,7 +81,7 @@ return new class extends Migration
                 ->cascadeOnDelete();
 
             if ($teams) {
-                $table->uuid($teamKey)->nullable();
+                $table->uuid($teamKey);
                 $table->index($teamKey, 'model_has_permissions_school_id_index');
 
                 $table->primary([$teamKey, $pivotPermission, $modelKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
@@ -103,7 +103,7 @@ return new class extends Migration
                 ->cascadeOnDelete();
 
             if ($teams) {
-                $table->uuid($teamKey)->nullable();
+                $table->uuid($teamKey);
                 $table->index($teamKey, 'model_has_roles_school_id_index');
 
                 $table->primary([$teamKey, $pivotRole, $modelKey, 'model_type'], 'model_has_roles_role_model_type_primary');

--- a/database/migrations/2026_02_05_000003_add_result_comment_mode_to_schools_table.php
+++ b/database/migrations/2026_02_05_000003_add_result_comment_mode_to_schools_table.php
@@ -8,34 +8,15 @@ return new class extends Migration
 {
     public function up()
     {
-        if (Schema::hasColumn('schools', 'result_comment_mode')) {
-            return;
-        }
-
-        $afterColumn = null;
-        if (Schema::hasColumn('schools', 'result_show_remarks')) {
-            $afterColumn = 'result_show_remarks';
-        } elseif (Schema::hasColumn('schools', 'result_show_highest')) {
-            $afterColumn = 'result_show_highest';
-        } elseif (Schema::hasColumn('schools', 'current_term_id')) {
-            $afterColumn = 'current_term_id';
-        }
-
-        Schema::table('schools', function (Blueprint $table) use ($afterColumn) {
-            $column = $table->string('result_comment_mode', 20)->default('manual');
-
-            if ($afterColumn !== null) {
-                $column->after($afterColumn);
-            }
+        Schema::table('schools', function (Blueprint $table) {
+            $table->string('result_comment_mode', 20)->default('manual');
         });
     }
 
     public function down()
     {
-        if (Schema::hasColumn('schools', 'result_comment_mode')) {
-            Schema::table('schools', function (Blueprint $table) {
-                $table->dropColumn('result_comment_mode');
-            });
-        }
+        Schema::table('schools', function (Blueprint $table) {
+            $table->dropColumn('result_comment_mode');
+        });
     }
 };

--- a/database/migrations/2026_03_12_235315_add_release_at_to_agent_commissions_table.php
+++ b/database/migrations/2026_03_12_235315_add_release_at_to_agent_commissions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('agent_commissions', function (Blueprint $table) {
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('agent_commissions', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2026_03_13_005153_add_release_at_to_agent_commissions_table.php
+++ b/database/migrations/2026_03_13_005153_add_release_at_to_agent_commissions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('agent_commissions', function (Blueprint $table) {
+            $table->timestamp('release_at')->nullable()->after('status')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('agent_commissions', function (Blueprint $table) {
+            $table->dropColumn('release_at');
+        });
+    }
+};

--- a/tests/Feature/AgentSecurityTest.php
+++ b/tests/Feature/AgentSecurityTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\Agent;
+use App\Models\School;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+describe('AgentController Security — resolveAgent()', function () {
+    beforeEach(function () {
+        // Create an approved agent for testing
+        $this->agent = Agent::factory()->approved()->create();
+
+        // Create a school and admin user (different auth guard)
+        $this->school = School::factory()->create();
+        $this->admin = User::factory()->create([
+            'school_id' => $this->school->id,
+            'role' => 'admin',
+            'status' => 'active',
+        ]);
+    });
+
+    it('allows authenticated agent to access their own dashboard', function () {
+        // Act as the agent using the 'agent' guard
+        Sanctum::actingAs($this->agent, [], 'agent');
+
+        $response = getJson(route('agents.dashboard'));
+
+        $response->assertOk();
+        $response->assertJsonPath('agent.id', $this->agent->id);
+    });
+
+    it('prevents school admin from accessing agent dashboard via agent_id param', function () {
+        // Act as the school admin (sanctum guard, NOT agent guard)
+        Sanctum::actingAs($this->admin, [], 'sanctum');
+
+        // Try to access agent dashboard by passing agent_id in query string
+        $response = getJson(route('agents.dashboard') . '?agent_id=' . $this->agent->id);
+
+        // Should be rejected — school admin is NOT an agent
+        $response->assertUnauthorized();
+    });
+
+    it('prevents school admin from requesting payouts using agent_id param', function () {
+        Sanctum::actingAs($this->admin, [], 'sanctum');
+
+        $response = postJson(route('agents.payouts.request'), [
+            'agent_id' => $this->agent->id,
+            'amount' => 50000,
+        ]);
+
+        $response->assertUnauthorized();
+    });
+
+    it('prevents school admin from generating referral codes using agent_id param', function () {
+        Sanctum::actingAs($this->admin, [], 'sanctum');
+
+        $response = postJson(route('agents.referrals.generate'), [
+            'agent_id' => $this->agent->id,
+        ]);
+
+        $response->assertUnauthorized();
+    });
+
+    it('returns 401 for completely unauthenticated requests to agent endpoints', function () {
+        // No authentication at all
+        getJson(route('agents.dashboard'))->assertUnauthorized();
+        getJson(route('agents.profile'))->assertUnauthorized();
+        postJson(route('agents.referrals.generate'))->assertUnauthorized();
+        postJson(route('agents.payouts.request'))->assertUnauthorized();
+    });
+});
+
+describe('Agent Authentication — Login & Token', function () {
+    it('allows agent to register and receive confirmation', function () {
+        $response = postJson(route('agents.register'), [
+            'full_name' => 'Test Agent',
+            'email' => 'test.agent@example.com',
+            'password' => 'SecurePass123!',
+            'password_confirmation' => 'SecurePass123!',
+            'phone' => '+2349012345678',
+            'whatsapp_number' => '+2349012345678',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'message',
+            'agent' => ['id', 'email', 'full_name', 'status'],
+            'verification_required',
+        ]);
+        expect($response->json('agent.status'))->toBe('pending');
+        expect($response->json('verification_required'))->toBeTrue();
+    });
+
+    it('allows agent to login with correct credentials', function () {
+        $agent = Agent::factory()->create([
+            'email' => 'login.test@example.com',
+            'password' => 'MyPassword123!',
+            'email_verified_at' => now(),
+        ]);
+
+        $response = postJson(route('agents.login'), [
+            'email' => 'login.test@example.com',
+            'password' => 'MyPassword123!',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure(['agent', 'token']);
+        expect($response->json('agent.id'))->toBe($agent->id);
+    });
+
+    it('rejects agent login with wrong password', function () {
+        Agent::factory()->create([
+            'email' => 'wrong.pass@example.com',
+            'password' => 'CorrectPassword123!',
+            'email_verified_at' => now(),
+        ]);
+
+        $response = postJson(route('agents.login'), [
+            'email' => 'wrong.pass@example.com',
+            'password' => 'WrongPassword!',
+        ]);
+
+        // Laravel throws ValidationException which returns 422
+        $response->assertStatus(422);
+    });
+});

--- a/tests/Feature/CommissionCoolingOffTest.php
+++ b/tests/Feature/CommissionCoolingOffTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Agent;
+use App\Models\AgentCommission;
+use App\Services\CommissionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CommissionCoolingOffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CommissionService $commissionService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->commissionService = app(CommissionService::class);
+    }
+
+    /** @test */
+    public function it_does_not_auto_approve_commissions_during_cooling_off_period()
+    {
+        $agent = Agent::factory()->create();
+        $school = \App\Models\School::factory()->create();
+        $referral = \App\Models\Referral::create([
+            'agent_id' => $agent->id,
+            'school_id' => $school->id,
+            'referral_code' => 'TESTCODE',
+            'referral_link' => 'http://localhost/ref/TESTCODE',
+            'status' => 'active',
+        ]);
+        
+        // Create a commission that was just created (within 72h window)
+        $commission = AgentCommission::create([
+            'agent_id' => $agent->id,
+            'referral_id' => $referral->id,
+            'school_id' => $school->id,
+            'commission_amount' => 1000,
+            'status' => 'pending',
+            'release_at' => now()->addHours(72),
+            'payment_number' => 1,
+        ]);
+
+        // Trigger earnings calculation (which calls autoApprove)
+        $this->commissionService->getAgentEarnings($agent);
+
+        // Assert it is still pending
+        $this->assertEquals('pending', $commission->fresh()->status);
+    }
+
+    /** @test */
+    public function it_auto_approves_commissions_after_cooling_off_period_passes()
+    {
+        $agent = Agent::factory()->create();
+        $school = \App\Models\School::factory()->create();
+        $referral = \App\Models\Referral::create([
+            'agent_id' => $agent->id,
+            'school_id' => $school->id,
+            'referral_code' => 'TESTCODE2',
+            'referral_link' => 'http://localhost/ref/TESTCODE2',
+            'status' => 'active',
+        ]);
+        
+        // Create a commission whose release time has passed
+        $commission = AgentCommission::create([
+            'agent_id' => $agent->id,
+            'referral_id' => $referral->id,
+            'school_id' => $school->id,
+            'commission_amount' => 1000,
+            'status' => 'pending',
+            'release_at' => now()->subHour(),
+            'payment_number' => 1,
+        ]);
+
+        // Trigger earnings calculation
+        $this->commissionService->getAgentEarnings($agent);
+
+        // Assert it is now approved
+        $this->assertEquals('approved', $commission->fresh()->status);
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This PR introduces a **72-hour cooling-off period** for agent commissions to prevent fraudulent payouts. Commissions are now created in a `pending` state with a `release_at` timestamp and are only eligible for auto-approval once that window has passed.

- **Infrastructure**: Added `release_at` column to `agent_commissions`.
- **Logic**: Updated `CommissionService` to enforce the delay and only auto-approve matured commissions.
- **Config**: Added `cooling_off_hours` to `config/commission.php`.
- **Environment**: Updated `config/database.php` for PHP 8.5 compatibility and added new variables to `.env.example`.

## Related Issue

Closes https://github.com/Cyfamod-Technologies/school-be-laravel/issues/64

## Motivation and Context

**The Vulnerability:**
Before this PR, the system was "Naive." If an agent created a fake school and "paid" with a stolen credit card, the system immediately said: "Success! Agent, here is your 12% commission. It's already approved. You can withdraw it now." The agent could withdraw the money and disappear within minutes. By the time the bank realized the credit card was stolen (usually 24-48 hours later), the business would have already lost real cash.

**The Solution:**
This PR introduces **"Time-Locked Trust."** We no longer trust a sale the second it happens. We force a mandatory **72-hour "Cooling-off" period**. This gives administrators 3 days to verify if the school's payment was legitimate before the agent can even see that money as withdrawable.


## Screenshots
<img width="444" height="401" alt="image" src="https://github.com/user-attachments/assets/7a4a52db-02d7-417d-b643-838bbbe1665e" />


## How Has This Been Tested?

- **Test Suite**: Created `CommissionCoolingOffTest`.
- **Scenarios**: 
  1. Verified that commissions remain `pending` during the cooling-off window.
  2. Verified that commissions correctly transition to `approved` after the 72-hour period.
- **Environment**: PHP 8.5.3, MariaDB 11.4.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new tests passed.